### PR TITLE
don't log warnings at inappropriately high log levels

### DIFF
--- a/usr/share/time-slider/lib/time_slider/timesliderd.py
+++ b/usr/share/time-slider/lib/time_slider/timesliderd.py
@@ -800,17 +800,17 @@ class SnapshotManager(threading.Thread):
         for zpool in self._zpools:
             status = self._poolstatus[zpool.name]
             if status == 4:
-                syslog.syslog(syslog.LOG_EMERG,
+                syslog.syslog(syslog.LOG_WARNING,
                               "%s is over %d%% capacity. " \
                               "All automatic snapshots were destroyed" \
                                % (zpool.name, self._emergencyLevel))
             elif status == 3:
-                syslog.syslog(syslog.LOG_ALERT,
+                syslog.syslog(syslog.LOG_WARNING,
                               "%s exceeded %d%% capacity. " \
                               "Automatic snapshots over 1 hour old were destroyed" \
                                % (zpool.name, self._emergencyLevel))
             elif status == 2:
-                syslog.syslog(syslog.LOG_CRIT,
+                syslog.syslog(syslog.LOG_WARNING,
                               "%s exceeded %d%% capacity. " \
                               "Weekly, hourly and daily automatic snapshots were destroyed" \
                                % (zpool.name, self._criticalLevel))                             


### PR DESCRIPTION
time-slider has the really nasty habit of logging warnings at inappropriately high log levels when pools are full, even if it isn't supposed to do anything with those pools. Ideally time-slider could be fixed to detect which pools it should care about or not, but that didn't look simple enough for what little python I know. Instead I'll just fix the logging.

So depending on how full a pool is time slider will log at LOG_EMERG, LOG_ALERT, or LOG_CRIT. None of those are appropriate log levels for time-slider. Lets take a look at syslog(3C) for a description of those log levels:

```
   LOG_EMERG
                  A panic condition.  This is normally broadcast to all
                  users.

   LOG_ALERT
                  A condition that should be corrected immediately, such
                  as a corrupted system database.

   LOG_CRIT
                  Critical conditions, such as hard device errors.
```

A pool being 90% or even 99% full is in no way a hard device error, nor is there anything corrupted and needs to be corrected immediately, nor is it a panic condition. And the warning definitely doesn't have to show up every few minutes on every xterm (thats what "broadcast to all users" boils down to).

So, make time-slider behave and log warnings at LOG_WARNING.
