### PR TITLE
9919 Fix index error in function list_filesystems

### DIFF
--- a/usr/share/time-slider/lib/time_slider/zfs.py
+++ b/usr/share/time-slider/lib/time_slider/zfs.py
@@ -235,7 +235,8 @@ class Datasets(Exception):
                                     (str(cmd), err, errdata)
             for line in outdata.rstrip().split('\n'):
                 line = line.rstrip().split()
-                Datasets.filesystems.append([line[0], line[1]])
+                if len(outdata) > 1:
+                    Datasets.filesystems.append([line[0], line[1]])
         Datasets._filesystemslock.release()
 
         if pattern == None:


### PR DESCRIPTION
`zfs list` does empty output when running from a CD.